### PR TITLE
DEPLOY-95: Handle Zinc Timeout with no backup

### DIFF
--- a/states/_modules/cfutils.py
+++ b/states/_modules/cfutils.py
@@ -86,3 +86,5 @@ def get_colo_names(timeout=10: int, backup=True: bool) -> list[str]:
 
     if backup:
         return __salt__["provision_api.get_names"](type="colo", timeout=timeout)
+    else:
+        return []

--- a/tests/pytests/unit/_modules/test_cfutils.py
+++ b/tests/pytests/unit/_modules/test_cfutils.py
@@ -122,6 +122,11 @@ def test_get_colo_names_timeout_from_zinc_falls_back_to_provision_api() -> None:
     with mock_server("provision_api", "get_names", 200, ["provision_api_colo"]):
         assert cfutils.get_colo_names() == ["provision_api_colo"]
 
+# Slow test due to the wait for a Zinc timeout (10s)
+@pytest.mark.slow
+def test_get_colo_names_timeout_from_zinc_with_no_backup() -> None:
+    assert cfutils.get_colo_names(backup = False) == []
+
 # Really slow test due to wait for both Zinc and Provision API timeout (20s)
 @pytest.mark.slow
 def test_get_colo_names_returns_error_on_backup_failure() -> None:


### PR DESCRIPTION
[DEPLOY-95](https://gist.github.com/jwalterclark/e921eae77751a710f74816412ff37e82): Handles the situation where Zinc times out and backup=False, returning an empty list rather than None

Note We should probably refactor this to use mocks (or even a lower timeout on the Zinc requests to reduce the test timing), but I didn't do it now as it would have blown the PR up